### PR TITLE
Speichern von Patienten

### DIFF
--- a/App.cs
+++ b/App.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
+using System.IO;
 using System.Windows.Forms;
 
 namespace DocCentral.WinForms
@@ -22,6 +23,8 @@ namespace DocCentral.WinForms
         {
             Host = Configure();
         }
+
+        public static LiteDatabase DB;
 
         /// <summary>
         /// Stellt den Zugriff auf die Applikationsklasse bereit.
@@ -80,8 +83,7 @@ namespace DocCentral.WinForms
             //services.AddLogging(logging => logging.AddConsole());
 
             // Services für den Zugriff auf Patientendaten konfigurieren
-            var db = new LiteDatabase(":memory:");
-            services.AddSingleton<ILiteDBConfiguration>(new LiteDBConfiguration(db));
+            services.AddSingleton<ILiteDBConfiguration>(new LiteDBConfiguration(DB));
             services.AddSingleton<IPatientService, LiteDBPatientService>();
 
             // Konfiguriere Zugriff auf ViewModel von den Views aus

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using LiteDB;
+using System;
+using System.IO;
 using System.Windows.Forms;
 
 namespace DocCentral.WinForms
@@ -17,8 +19,17 @@ namespace DocCentral.WinForms
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            var shellView = App.Current.GetService<ShellView>();
-            Application.Run(shellView);
+            // Benötigen wir eine In-Memory DB, können wir als dbname auch ":memory:" verwenden.
+            // Wir speichern aber die DB im Roadmin-Profile, so dass sie immer wieder vorhanden ist.
+            var dbpath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var dbname = Path.Combine(dbpath, "DocCentral.db");
+            using (var db = new LiteDatabase(dbname))
+            {
+                App.DB = db;
+
+                var shellView = App.Current.GetService<ShellView>();
+                Application.Run(shellView);
+            }
         }
     }
 }

--- a/Services/FakePatientService.cs
+++ b/Services/FakePatientService.cs
@@ -19,5 +19,15 @@ namespace DocCentral.WinForms.Services
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Aktualisiert einen bestehenden Patienten. Kommt es bei der Aktualisierung
+        /// zu einem Fehler, so wird eine Ausnahme geworfen.
+        /// </summary>
+        /// <param name="request">Zu aktualisierender Patient</param>
+        public Task UpdateAsync(UpdatePatientRequest request)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Services/IPatientService.cs
+++ b/Services/IPatientService.cs
@@ -1,4 +1,5 @@
 ﻿using DocCentral.WinForms.DTOs;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -22,6 +23,13 @@ namespace DocCentral.WinForms.Services
         /// <param name="request">Filter für die Suchergebnisse</param>
         /// <returns>Suchergebnis als <see cref="SearchPatientsResponse"/></returns>
         Task<SearchPatientsResponse> SearchPatientsAsync(SearchPatientsRequest request);
+
+        /// <summary>
+        /// Aktualisiert einen bestehenden Patienten. Kommt es beim Aktualisieren zu
+        /// einem Fehler, so wird eine Ausnahme geworfen.
+        /// </summary>
+        /// <param name="request">Zu aktualisierender Patient</param>
+        Task UpdateAsync(UpdatePatientRequest request);
     }
 
     /// <summary>
@@ -75,5 +83,45 @@ namespace DocCentral.WinForms.Services
         /// angegebenen Einschränkungen.
         /// </summary>
         public IList<PatientDTO> Data { get; set; }
+    }
+
+    /// <summary>
+    /// Anfrage zum Aktualisieren eines Patienten. Wir tun dies anhand einer
+    /// eigenen Struktur, um auszudrücken, dass nur bestimmte EIgenschaften
+    /// eines Patienten überhaupt aktualisierbar sind (etwa Vorname, Nachname
+    /// und Geburtsdatum, nicht aber dessen Id).
+    /// </summary>
+    public class UpdatePatientRequest
+    {
+        private int _id;
+
+        /// <summary>
+        /// Konstruktor.
+        /// </summary>
+        /// <param name="id">Id des zu aktualisierenden Patienten</param>
+        public UpdatePatientRequest(int id)
+        {
+            _id = id;
+        }
+
+        /// <summary>
+        /// Id des zu aktualisierenden Patienten.
+        /// </summary>
+        public int Id { get => _id; }
+
+        /// <summary>
+        /// Setzt den Vornamen des zu aktualisierenden Patienten.
+        /// </summary>
+        public string FirstName { get; set; }
+
+        /// <summary>
+        /// Setzt den Nachname des zu aktualisierenden Patienten.
+        /// </summary>
+        public string LastName { get; set; }
+
+        /// <summary>
+        /// Setzt das Geburtsdatum des zu aktualisierenden Patienten.
+        /// </summary>
+        public DateTime DateOfBirth { get; set; }
     }
 }

--- a/Services/LiteDBPatientService.cs
+++ b/Services/LiteDBPatientService.cs
@@ -106,6 +106,25 @@ namespace DocCentral.WinForms.Services
                 return response;
             });
         }
+
+        /// <summary>
+        /// Aktualisiert einen bestehenden Patienten. Kommt es bei der Aktualisierung
+        /// zu einem Fehler, so wird eine Ausnahme geworfen.
+        /// </summary>
+        /// <param name="request">Zu aktualisierender Patient</param>
+        public async Task UpdateAsync(UpdatePatientRequest request)
+        {
+            var dto = await GetPatientByIdAsync(request.Id);
+            dto.FirstName = request.FirstName;
+            dto.LastName = request.LastName;
+            dto.DateOfBirth = request.DateOfBirth;
+
+            var success = Patients.Update(dto);
+            if (!success)
+            {
+                throw new ApplicationException($"Patient {request.Id} wurde nicht gefunden");
+            }
+        }
     }
 
     /// <summary>

--- a/ViewModels/PatientEditViewModel.cs
+++ b/ViewModels/PatientEditViewModel.cs
@@ -47,5 +47,28 @@ namespace DocCentral.WinForms.ViewModels
             var patientDto = await _patientService.GetPatientByIdAsync(patientId);
             Patient = new Patient(patientDto);
         }
+
+        /// <summary>
+        /// Aktualisiert den Patienten. Es ist Aufgabe des Aufrufers, anschließend
+        /// den neuen Patienten zu laden (sofern dies notwendig ist). Kommt es beim
+        /// Aktualisieren zu einem Fehler, so wird eine Ausnahme geworfen.
+        /// </summary>
+        /// <returns><see cref="Task"/></returns>
+        public async Task UpdateAsync()
+        {
+            if (_patient == null)
+            {
+                throw new InvalidOperationException("Patient muss geladen werden bevor er gespeichert werden kann");
+            }
+
+            var request = new UpdatePatientRequest(Patient.Id)
+            {
+                FirstName = Patient.FirstName,
+                LastName = Patient.LastName,
+                DateOfBirth = Patient.DateOfBirth,
+            };
+
+            await _patientService.UpdateAsync(request);
+        }
     }
 }

--- a/Views/PatientEditView.cs
+++ b/Views/PatientEditView.cs
@@ -18,6 +18,10 @@ namespace DocCentral.WinForms.Views
     {
         private readonly int _patientId;
 
+        /// <summary>
+        /// Konstruktor des Fensters.
+        /// </summary>
+        /// <param name="patientId">Zu bearbeitender Patient</param>
         public PatientEditView(int patientId)
         {
             _patientId = patientId;
@@ -58,11 +62,24 @@ namespace DocCentral.WinForms.Views
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void SaveOnClick(object sender, EventArgs e)
+        private async void SaveOnClick(object sender, EventArgs e)
         {
-            MessageBox.Show("Speichern ist noch nicht implementiert", "Hinweis", MessageBoxButtons.OK);
+            try
+            {
+                await ViewModel.UpdateAsync();
+                DialogResult = DialogResult.OK;
+                Close();
+            }
+            catch(Exception ex)
+            {
+                MessageBox.Show("Das Aktualisieren ist fehlgeschlagen:" +
+                    Environment.NewLine +
+                    Environment.NewLine +
+                    ex.Message,
+                    "Fehler",
+                    MessageBoxButtons.OK);
+            }
 
-            Close();
         }
 
         /// <summary>

--- a/Views/PatientsSearchView.cs
+++ b/Views/PatientsSearchView.cs
@@ -104,7 +104,7 @@ namespace DocCentral.WinForms.Views
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void DataGridOnCellDoubleClick(object sender, DataGridViewCellEventArgs e)
+        private async void DataGridOnCellDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
             // Da das DataGrid direkt an Instanzen des Typs PatientSearchResult bindet,
             // können wir hier direkt auf die gebundene Instanz zugreifen
@@ -114,7 +114,8 @@ namespace DocCentral.WinForms.Views
             var editView = new PatientEditView(result.Id);
             if (editView.ShowDialog() == DialogResult.OK)
             {
-                // TODO Hier müssen wir nun das DataGrid aktualisieren
+                // Hier müssen wir nun das DataGrid aktualisieren
+                await ViewModel.SearchAsync();
             }
         }
     }


### PR DESCRIPTION
Dieses Commit implementiert das Speichern von Patienten.

Nach dem erfolgreichen Speichern wird das
Bearbeitungsfenster geschlossen und die Suche
erneut ausgeführt, um die Änderungen
widerzuspielen.

Zudem speichern wir die DB nun im Roaming-Profile,
und nicht mehr nur im Hauptspeicher.